### PR TITLE
#147: add folder picker for backup images

### DIFF
--- a/electron/main/ipc/index.ts
+++ b/electron/main/ipc/index.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, ipcMain } from 'electron';
 import { indexHtml, preload, url } from '../paths';
 import './ipc-openai';
 import './ipc-vault';
+import './ipc-dialogs';
 
 ipcMain.handle('open-win', (_, arg) => {
   const childWindow = new BrowserWindow({

--- a/electron/main/ipc/ipc-dialogs.ts
+++ b/electron/main/ipc/ipc-dialogs.ts
@@ -1,0 +1,49 @@
+import { dialog, ipcMain } from 'electron';
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+
+const imageExtensionExpression = /\.(png|jpe?g|gif|webp)$/i;
+
+async function listFolder(folder: string): Promise<string[]> {
+  const contents = await readdir(folder, {
+    recursive: false,
+    encoding: 'utf-8',
+    withFileTypes: true,
+  });
+  return contents
+    .filter((entry) => entry.isFile())
+    .filter((entry) => imageExtensionExpression.test(entry.name))
+    .map((entry) => join(folder, entry.name));
+}
+
+async function loadImage(path: string): Promise<string> {
+  const contents = await readFile(path);
+  return contents.toString('base64');
+}
+
+async function pickImageFiles(folder: string, howMany: number) {
+  if (howMany <= 0) return [];
+  const picked: string[] = [];
+  const available = await listFolder(folder);
+  if (available.length < howMany) return available;
+  while (picked.length < howMany) {
+    const pickedIndex = Math.ceil(Math.random() * available.length);
+    const [pickedFile] = available.splice(pickedIndex, 1);
+    picked.push(pickedFile);
+  }
+  return picked;
+}
+
+ipcMain.handle('select-folder', async (): Promise<string | undefined> => {
+  const result = await dialog.showOpenDialog({
+    properties: ['openDirectory'],
+  });
+  if (result.canceled) return;
+  return result.filePaths[0];
+});
+
+ipcMain.handle('pick-random-images', async (_, folder: string, howMany: number): Promise<string[]> => {
+  const picked = await pickImageFiles(folder, howMany);
+  console.debug('Picks', JSON.stringify(picked));
+  return await Promise.all(picked.map((pick) => loadImage(pick)));
+});

--- a/src/components/FolderPicker/FolderPicker.spec.ts
+++ b/src/components/FolderPicker/FolderPicker.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ipcRenderer } from 'electron';
+import FolderPicker from './FolderPicker.vue';
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: vi.fn(),
+  },
+}));
+
+describe('FolderPicker', () => {
+  it('renders correctly', () => {
+    const wrapper = mount(FolderPicker);
+    expect(wrapper.find('.folder-picker').exists()).toBe(true);
+  });
+
+  it('calls selectFolder on button click', async () => {
+    const wrapper = mount(FolderPicker);
+    await wrapper.find('button').trigger('click');
+
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('select-folder');
+  });
+
+  it('updates folder path and emits event when a folder is selected', async () => {
+    const selectedFolder = '/path/to/folder';
+    (ipcRenderer.invoke as vi.Mock).mockResolvedValue(selectedFolder);
+
+    const wrapper = mount(FolderPicker);
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.vm).toHaveProperty('folder', selectedFolder);
+    expect(wrapper.emitted()['update:folder']).toBeTruthy();
+    expect(wrapper.emitted()['update:folder'][0]).toEqual([selectedFolder]);
+  });
+});

--- a/src/components/FolderPicker/FolderPicker.vue
+++ b/src/components/FolderPicker/FolderPicker.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ipcRenderer } from 'electron';
+import Button from 'primevue/button';
+import { ref } from 'vue';
+
+defineProps({
+  label: {
+    type: String,
+    default: 'Pick',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:folder']);
+
+const folder = ref<string>('');
+const selectFolder = async () => {
+  const selectedFolder: string | undefined = await ipcRenderer.invoke('select-folder');
+  if (!selectedFolder) return;
+  folder.value = selectedFolder;
+  emit('update:folder', selectedFolder);
+};
+</script>
+
+<template>
+  <div class="folder-picker" data-testid="folder-picker">
+    <Button :label="label" :disabled="disabled" @click="selectFolder" />
+    <div class="folder" :title="folder">{{ folder }}</div>
+  </div>
+</template>
+
+<style scoped>
+.folder-picker {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+}
+
+.folder {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/src/components/LoadDialog/LoadDialog.vue
+++ b/src/components/LoadDialog/LoadDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import type { FileUploadSelectEvent } from 'primevue/fileupload';
 import FileUpload from 'primevue/fileupload';
-import type { FileUploadRemoveUploadedFile } from 'primevue/fileupload';
 import { usePresentation } from '../../stores/presentation';
 import { useIo } from '../../composables/useIo';
 
@@ -8,7 +8,7 @@ const { load } = useIo();
 const presentation = usePresentation();
 const emit = defineEmits(['loaded']);
 
-const uploader = async (event: FileUploadRemoveUploadedFile) => {
+const uploader = async (event: FileUploadSelectEvent) => {
   const file = event.files[0];
   const loaded = await load(file);
   presentation.load(loaded);

--- a/src/components/SlideEditor/TopicInput.vue
+++ b/src/components/SlideEditor/TopicInput.vue
@@ -27,7 +27,7 @@ const topic = ref<string>(props.topic);
 
 const suggestTopic = async () => {
   await op(async () => {
-    topic.value = await findTopic(props.topicPrompt);
+    topic.value = await findTopic();
   });
 };
 </script>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Allows you to use a backup folder for slide images for when you don't want to AI generated *everything.*

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
