### PR TITLE
NOISSUE: Release 0.2.1

### DIFF
--- a/.changeset/hungry-lies-sleep.md
+++ b/.changeset/hungry-lies-sleep.md
@@ -1,5 +1,0 @@
----
-'karaokai': patch
----
-
-Simplify GPT interactions regarding slide generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # KaraokAI
 
+## 0.2.1
+
+### Patch Changes
+
+- 8f8e2e1: Simplify GPT interactions regarding slide generation
+
 ## 0.2.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karaokai",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karaokai",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "openai": "4.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karaokai",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "dist-electron/main/index.js",
   "description": "PowerPoint Karaoke - but AI-powered",
   "author": "Manuel Warum <mwarum@gmail.com>",


### PR DESCRIPTION
Release 0.2.1, which is mainly a maintenance release (bumped dependencies and whatnot).
